### PR TITLE
Changes insterion to selection sort in the Wikipidea link section

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ This algorithm never needed to compare all the differences to one another, savin
 #### Visualization
 ![#](https://upload.wikimedia.org/wikipedia/commons/9/94/Selection-Sort-Animation.gif)
 
-[(source: Wikipedia, _Insertion Sort_)](https://en.wikipedia.org/wiki/Selection_sort)
+[(source: Wikipedia, _Selection Sort_)](https://en.wikipedia.org/wiki/Selection_sort)
 
 ### <a id="insertion-sort"></a>Insertion Sort
 #### Definition


### PR DESCRIPTION
The Wikipedia Link for the Selection Sort Had the wrong heading , it said insertion sort in the place of Selection sort.
I changed it back.